### PR TITLE
Make the script installable and add test coverage reporting

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[html]
+show_contexts = True

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -31,3 +31,8 @@ jobs:
     - name: Test
       run: |
         pytest
+    - name: Save coverage report
+      uses: actions/upload-artifact@v2
+      with:
+        name: coverage-${{ matrix.python-version }}-${{ matrix.platform }}
+        path: htmlcov

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade setuptools pip wheel
-        python -m pip install -r requirements.txt
+        python -m pip install -e .[dev]
     - name: Check code style
       run: |
         invoke check

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 venv
 __pycache__
 *.egg-info
+.coverage
+htmlcov

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .python-version
 venv
 __pycache__
+*.egg-info

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Set up your development environment:
     ```
     $ python -m pip install -U setuptools pip wheel
 
-    $ python -m pip install -r requirements.txt
+    $ python -m pip install -e .[dev]
     ```
 
     This will install:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,7 @@
+[pytest]
+addopts = 
+    --cov=src
+    --cov-branch
+    --cov-context=test
+    --cov-report=term:skip-covered
+    --cov-report=html

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,0 @@
--e .
-black
-flake8
-flake8-docstrings
-invoke
-isort
-mypy
-pep8-naming
-pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+-e .
 black
 flake8
 flake8-docstrings

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ dev =
     mypy
     pep8-naming
     pytest
+    pytest-cov
 
 [options.packages.find]
 where = src

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,11 @@
+[metadata]
+name = google_voice_history
+
+[options]
+packages =
+    find:
+package_dir =
+    =src
+
+[options.packages.find]
+where = src

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,5 +7,16 @@ packages =
 package_dir =
     =src
 
+[options.extras_require]
+dev =
+    black
+    flake8
+    flake8-docstrings
+    invoke
+    isort
+    mypy
+    pep8-naming
+    pytest
+
 [options.packages.find]
 where = src

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,5 @@
+# type: ignore
+# noqa: D100
+import setuptools
+
+setuptools.setup()

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -1,0 +1,35 @@
+# type: ignore
+"""Tests of google_voice_history."""
+import pathlib
+import sys
+
+import pytest
+
+import google_voice_history
+
+TESTS_PATH = pathlib.Path(__file__).parent.resolve()
+
+
+@pytest.fixture
+def patch_argv(monkeypatch):
+    """Set command line arguments."""
+
+    def patch(*args):
+        name = google_voice_history.__file__
+        args = [str(x) for x in args]
+        monkeypatch.setattr(sys, "argv", [name, *args])
+
+    return patch
+
+
+def test_example(patch_argv, capsys):
+    """Generate example CSV from example takeout."""
+    patch_argv(TESTS_PATH / "takeout.zip")
+
+    google_voice_history.main()
+
+    with open(TESTS_PATH / "history.csv") as f:
+        example_csv = f.read()
+
+    captured = capsys.readouterr()
+    assert captured.out == example_csv

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -1,5 +1,5 @@
 # type: ignore
-"""Tests for google_voice_history.py."""
+"""Tests of running `python google_voice_history.py`."""
 import pathlib
 import re
 import subprocess


### PR DESCRIPTION
Adding the coverage report was my goal, but in order to do that, I had to `import` the script in the tests, and the recommended way to do that is by supporting `pip install`.

For reference:

- https://docs.pytest.org/en/latest/goodpractices.html#install-package-with-pip
- https://github.com/pytest-dev/pytest/issues/2421#issuecomment-332158308
- https://setuptools.readthedocs.io/en/latest/setuptools.html#configuring-setup-using-setup-cfg-files

Current test results:

```
============================= test session starts ==============================
platform darwin -- Python 3.7.3, pytest-6.0.1, py-1.9.0, pluggy-0.13.1
rootdir: /Users/brian/Code/google-voice-history, configfile: pytest.ini
plugins: cov-2.10.1
collected 4 items

tests/test_module.py .                                                   [ 25%]
tests/test_script.py ...                                                 [100%]

---------- coverage: platform darwin, python 3.7.3-final-0 -----------
Name                          Stmts   Miss Branch BrPart  Cover
---------------------------------------------------------------
src/google_voice_history.py     110     10     30      5    89%
Coverage HTML written to dir htmlcov


============================== 4 passed in 0.57s ===============================
```